### PR TITLE
Treat null like undefined when creating object paths

### DIFF
--- a/dist/imtbl.js
+++ b/dist/imtbl.js
@@ -7,6 +7,8 @@
 const isObject = v =>
   v !== null && typeof v === "object" && Array.isArray(v) === false;
 
+const isNil = v => v === undefined || v === null;
+
 const assoc = (coll, ...kvs) => {
   let ret = coll;
 
@@ -72,7 +74,7 @@ const conj = (coll, ...xs) => {
   return ret;
 };
 
-const get = (m, k, notFound) => (m[k] !== undefined ? m[k] : notFound);
+const get = (m, k, notFound) => (isNil(m[k]) ? notFound : m[k]);
 
 const getIn = (m, ks, notFound) => {
   let ret = m;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 const isObject = v =>
   v !== null && typeof v === "object" && Array.isArray(v) === false;
 
+const isNil = v => v === undefined || v === null;
+
 export const assoc = (coll, ...kvs) => {
   let ret = coll;
 
@@ -66,7 +68,7 @@ export const conj = (coll, ...xs) => {
   return ret;
 };
 
-export const get = (m, k, notFound) => (m[k] !== undefined ? m[k] : notFound);
+export const get = (m, k, notFound) => (isNil(m[k]) ? notFound : m[k]);
 
 export const getIn = (m, ks, notFound) => {
   let ret = m;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,6 +51,7 @@ test("assoc", () => {
 test("assocIn", () => {
   const in1 = { a: {} };
   const in2 = [{ a: [] }];
+  const in3 = { a: null };
 
   expect(assocIn(in1, ["a", "b"], 1)).toEqual({ a: { b: 1 } });
   expect(in1).toEqual({ a: {} });
@@ -65,6 +66,9 @@ test("assocIn", () => {
   expect(assocIn({ a: [] }, ["a", 0], 1)).toEqual({ a: [1] });
   expect(assocIn(in2, [0, "a", 1], 1)).toEqual([{ a: [, 1] }]);
   expect(in2).toEqual([{ a: [] }]);
+
+  expect(assocIn(in3, ['a', 'b'], 1)).toEqual({ a: { b: 1 } });
+  expect(in3).toEqual({ a: null });
 });
 
 test("dissoc", () => {


### PR DESCRIPTION
Hey. Here is a patch to make `null` be handled as `undefined` in simple case. Ref #2 

One other problem I've run into (possibly for another ticket) is using arrays when path key is numeric.

E.g. when you
```js
assocIn({}, ['a', 0, 'b'], 2)
```
I'd expect
```js
{ a: [{ b: 2 }] }
```
but ATM I get
```js
{ a: { 0: { b: 2 } } }
```

Lodash does it, but I'm not sure if that's a good argument, since this library is inspired by Clojure.